### PR TITLE
Readme update

### DIFF
--- a/roles/namespace/tasks/engine_enable.yml
+++ b/roles/namespace/tasks/engine_enable.yml
@@ -16,7 +16,7 @@
   uri:
     url: "{{ vault_url }}/v1/sys/mounts/{{ engine.mount_name }}"
     method: POST
-    body: '{"type": "{{ engine.mount_type }}","options":{"version":{{ engine.version | default(engine_version) }} },"config":{"default_lease_ttl":"{{ engine.default_ttl | default(engine_default_ttl)}}", "max_lease_ttl":"{{ engine.max_ttl | default(engine_max_ttl)}}" } }'
+    body: '{"type": "{{ engine.mount_type }}","config":{"default_lease_ttl":"{{ engine.default_ttl | default(engine_default_ttl)}}", "max_lease_ttl":"{{ engine.max_ttl | default(engine_max_ttl)}}" } {% if engine.mount_type == "kv" %}, "options":{"version":{{ engine.version | default(engine_version) }} }{% else %}{% endif %} }'
     headers:
       X-Vault-Token: "{{ lookup('env', 'VAULT_TOKEN') }}"
       X-Vault-Namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"

--- a/roles/namespace/tasks/main.yml
+++ b/roles/namespace/tasks/main.yml
@@ -34,7 +34,7 @@
 # TODO: check if policies match before applying (idempotent report)
 - name: write policies
   include_tasks: policy_write.yml
-  loop: "{{ policies.split(',') }}" #| replace(' ','')
+  loop: "{{ policies.split(',') }}"
   loop_control:
     loop_var: policy
 

--- a/roles/namespace/tasks/policy_write.yml
+++ b/roles/namespace/tasks/policy_write.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "create vault policies in {{ ns_name }}"
-  command: "{{ vault_bin }}/vault policy write {{ policy }} policies/{{ policy }}.hcl"
+  command: "{{ vault_bin }}/vault policy write {{ policy }} policies/{{ policy | replace(' ','')}}.hcl"
   environment:
     VAULT_ADDR: "{{ vault_url }}"
     VAULT_NAMESPACE: "{% if ns_name == 'root' %}{% else %}{{ ns_name | default('')}}{% endif %}"


### PR DESCRIPTION
update readme with `auths` related design changes

fix spacing issue in `policies` string

fix usage of `version` parameter when enabling non kv secret engines. only passed with `mount_type=kv`