### PR TITLE
strip check for 'root' namespace

### DIFF
--- a/roles/namespace/tasks/auth.yml
+++ b/roles/namespace/tasks/auth.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: "enable {{ auth.auth_type }} in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "enable {{ auth.auth_type }} in {{ ns_name }}"
   hashivault_auth_method:
     method_type: "{{ auth.auth_type }}"
     mount_point: "{{ auth.auth_name | default(auth.auth_type) }}"
     config: "{{ auth.mount_config | default({}) }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
 
 
 # Azure
-- name: "configure {{ auth.auth_type }} role in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure {{ auth.auth_type }} role in {{ ns_name }}"
   include_tasks: auth_config.yml
   loop: "{{ auth.auth_config.split(',') }}"
   loop_control:
@@ -19,7 +19,7 @@
 
 # Create role
 
-- name: "create {{ auth.auth_type }} role in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "create {{ auth.auth_type }} role in {{ ns_name }}"
   include_tasks: auth_role.yml
   loop: "{{ auth.roles.split(',') }}"
   loop_control:

--- a/roles/namespace/tasks/auth_config.yml
+++ b/roles/namespace/tasks/auth_config.yml
@@ -6,10 +6,10 @@
   
 # Azure
 
-- name: "configure {{ auth.auth_type }} auth method in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure {{ auth.auth_type }} auth method in {{ ns_name }}"
   hashivault_azure_auth_config:
     mount_point: "{{ auth.auth_name | default(auth.auth_type) }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
     tenant_id: "{{ tenant_id }}"
     client_id: "{{ client_id | default('') }}"
     resource: "{{ resource | default('') }}"

--- a/roles/namespace/tasks/auth_role.yml
+++ b/roles/namespace/tasks/auth_role.yml
@@ -9,7 +9,7 @@
 #needs to be idempotent and be accepted as a file
 # https://github.com/TerryHowe/ansible-modules-hashivault/issues/136
 # once fixed change this back to using file reference
-- name: "configure {{ role }} approle in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure {{ role }} approle in {{ ns_name }}"
   hashivault_approle_role_create:
     name: "{{ role }}"
     bind_secret_id: "{{ bind_secret_id | default('true') | bool }}"
@@ -22,12 +22,12 @@
     period: "{{ period | default('') }}"
     enable_local_secret_ids: "{{ enable_local_secret_ids | default('false') | bool }}"
     policies: "{{ policies | default([]) }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
   when: auth.auth_type | lower == 'approle'
 
 
 # Azure
-- name: "configure {{ auth.auth_type }} auth role in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure {{ auth.auth_type }} auth role in {{ ns_name }}"
   hashivault_azure_auth_role:
     name: "{{ role }}"
     role_file: "{{ playbook_dir }}/auths/{{ auth.auth_type }}/roles/{{ role }}.json"

--- a/roles/namespace/tasks/engine.yml
+++ b/roles/namespace/tasks/engine.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: "enable {{ engine.mount_type }} secret engine in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "enable {{ engine.mount_type }} secret engine in {{ ns_name }}"
   hashivault_secret_engine:
     name: "{{ engine.mount_name | default(engine.mount_type) }}"
     backend: "{{ engine.mount_type }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
     config: "{{ engine.mount_config | default({}) }}"
     options: "{{ engine.options | default({}) }}"
 
-- name: "configure {{ engine.mount_type }} secret engine in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure {{ engine.mount_type }} secret engine in {{ ns_name }}"
   include_tasks: engine_config.yml
   loop: "{{ engine.engine_config.split(',') }}"
   loop_control:

--- a/roles/namespace/tasks/engine_config.yml
+++ b/roles/namespace/tasks/engine_config.yml
@@ -6,10 +6,10 @@
   # Approle
 
 # Azure
-- name: "configure azure secret engine in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure azure secret engine in {{ ns_name }}"
   hashivault_azure_secret_engine_config:
     mount_point: "{{ engine.mount_name | default(engine.mount_type) }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
     tenant_id: "{{ tenant_id }}"
     subscription_id: "{{ subscription_id }}"
     environment: "{{ az_environment | default('AzurePublicCloud') }}"
@@ -19,11 +19,11 @@
 
 # Database
 
-- name: "configure database secret engine in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "configure database secret engine in {{ ns_name }}"
   hashivault_db_secret_engine_config:
     name: "{{ engine_config }}"
     mount_point: "{{ engine.mount_name | default(engine.mount_type) }}"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
     db_username:  "{{ username }}"
     db_password: "{{ password }}"
     plugin_name: "{{ plugin_name }}"

--- a/roles/namespace/tasks/engine_role.yml
+++ b/roles/namespace/tasks/engine_role.yml
@@ -4,19 +4,19 @@
 
 
 # Azure
-- name: "write azure secret engine role: {{ role }} in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "write azure secret engine role: {{ role }} in {{ ns_name }}"
   hashivault_azure_secret_engine_role:
     name: "{{ role }}"
     azure_role_file: "{{ playbook_dir }}/engines/azure/roles/{{ role }}.json"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
   when: engine.mount_type | lower == 'azure'
 
 
 # Database
-- name: "write database secret engine role: {{ role }} in {% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+- name: "write database secret engine role: {{ role }} in {{ ns_name }}"
   hashivault_db_secret_engine_role:
     name: "{{ role }}"
     role_file: "{{ playbook_dir }}/engines/database/roles/{{ role }}.json"
-    namespace: "{% if ns_name == 'root'%}{% else %}{{ ns_name }}{% endif %}"
+    namespace: "{{ ns_name }}"
   when: engine.mount_type | lower == 'database'
 

--- a/roles/namespace/tasks/main.yml
+++ b/roles/namespace/tasks/main.yml
@@ -2,18 +2,13 @@
 
 # in order to build child namespaces you need to indicate the the parent. these facts maintain the current
 # parent and the current child (looping through the namespaces_config_template.yml)
-# ns_child is set to "" if root. this is because the `X-Vault-Namespace` header will handle "" as the root namespace
-# and will not handle "root"
-# some of this logic can be simplified in a future release: https://github.com/hashicorp/vault/issues/5987
 - set_fact:
     ns_parent: "{% if ns_name.split('/') | count > 1 %}{{ ns_name.split('/')[:-1] | join('/') }}{% else %}{% endif %}"
-    ns_child: "{% if ns_name.split('/')[-1:] | join('') == 'root' %}{% else %}{{ ns_name.split('/')[-1:] | join('')  }}{% endif %}"
+    ns_child: "{{ ns_name.split('/')[-1:] | join('') }}"
 
-- name: "create namespace {{ ns_child }} {% if ns_parent != '' %}in {{ ns_parent }}{%else%}{%endif%}"
+- name: "create namespace {{ ns_child }} in {{ ns_parent }}"
   import_tasks: namespace_create.yml
-  when: ns_child != "" # skip if root namespace
-
-# Namespace should be set globally but change should wait for 'root' to be accepted namespace name
+  when: ns_child != "root" # skip if root namespace, already exists
 
 - name: enable auth mounts
   include_tasks: auth.yml

--- a/roles/namespace/tasks/policy_write.yml
+++ b/roles/namespace/tasks/policy_write.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: "create vault policies in {% if ns_name == 'root' %}{% else %}{{ ns_name | default('')}}{% endif %}"
+- name: "create vault policies in {{ ns_name }}"
   hashivault_policy_set_from_file:
       name: "{{ policy }}"
       rules_file: "{{ playbook_dir }}/policies/{{ policy | replace(' ','') }}.hcl" # remove spaces when list item contains
-      namespace: "{% if ns_name == 'root' %}{% else %}{{ ns_name | default('')}}{% endif %}"
+      namespace: "{{ ns_name }}"


### PR DESCRIPTION
https://github.com/hashicorp/vault/issues/5987

since 1.1.3, vault will now handle when namespace = 'root' this allows us to simplify logic around the `ns_name` and `ns_child` variable